### PR TITLE
Dtn axis display customization

### DIFF
--- a/projects/use_cases/src/demo/basic-plots-demo.js
+++ b/projects/use_cases/src/demo/basic-plots-demo.js
@@ -75,7 +75,7 @@ function demoColumnPlot(){
     const plotConfig = {
         padding: {top: 0}, 
         axis:{
-            x: {angle: 60, "text-anchor": "start"},
+            x: {angle: 60, textAnchor: "start"},
             y: {title: "value"}
         }
     }; // todo: yAxis title not showing
@@ -110,7 +110,7 @@ function demoStackedColumnPlot() {
         axis: {
             x: {
                 angle: 60,
-                "text-anchor": "start"
+                textAnchor: "start"
             }
         }
     };

--- a/projects/use_cases/src/demo/covid-us-map-demo.js
+++ b/projects/use_cases/src/demo/covid-us-map-demo.js
@@ -85,7 +85,7 @@ function createPlotData(data) {
                     scaleType: "temporal", 
                     ticks: 5,
                     angle: 30,
-                    "text-anchor": "start"
+                    textAnchor: "start"
                 },
                 y: {
                     title: "",

--- a/projects/use_cases/src/demo/scatterplot-histograms-demo.js
+++ b/projects/use_cases/src/demo/scatterplot-histograms-demo.js
@@ -37,7 +37,7 @@ function init(distri="randomNormal"){
             axis: {
                 x: {
                     angle: 90,
-                    "text-anchor": "start",
+                    textAnchor: "start",
                     title: ""
                 }
             }

--- a/src/controllers/Plot.js
+++ b/src/controllers/Plot.js
@@ -51,6 +51,7 @@ export class Plot {
                 orientation: "bottom", // top, bottom, left, right
                 padding: 0.15, // applicable for categorical scales
                 angle: 0,
+                textAnchor: undefined,
                 display: true, // setting this to false will hide the title, ticks, tick labels, and title. leave as true to fine-tune axis display settings
                 hideAxis: false, // will hide the axis (ticks + tick labels)
                 hideTicks: false, // will hide the axis ticks
@@ -66,6 +67,7 @@ export class Plot {
                 orientation: "left", // top, bottom, left, right
                 padding: 0.15, // applicable for categorical scales
                 angle: 0,
+                textAnchor: undefined,
                 display: true, // setting this to false will hide the title, ticks, tick labels, and title. leave as true to fine-tune axis display settings
                 hideAxis: false, // will hide the axis (ticks + tick labels)
                 hideTicks: false, // will hide the axis ticks

--- a/src/controllers/Plot.js
+++ b/src/controllers/Plot.js
@@ -46,23 +46,31 @@ export class Plot {
                 scaleType: undefined, // auto-detect if undefined
                 title: "x axis", 
                 ticks: undefined, // number of ticks to display
-                display: true, 
                 min: undefined, // applicable for numerical scales
-                max: undefined, // aaplicable for numerical scales
+                max: undefined, // applicable for numerical scales
                 orientation: "bottom", // top, bottom, left, right
                 padding: 0.15, // applicable for categorical scales
-                angle: 0
+                angle: 0,
+                display: true, // setting this to false will hide the title, ticks, tick labels, and title. leave as true to fine-tune axis display settings
+                hideAxis: false, // will hide the axis (ticks + tick labels)
+                hideTicks: false, // will hide the axis ticks
+                hideLabels: false, // will hide the axis tick labels
+                hideTitle: false // will hide the axis title
             },
             y: {
                 scaleType: undefined, // auto-detect if undefined
                 title: "y axis", 
                 ticks: undefined, // number of ticks to display
-                display: true, 
                 min: undefined, // applicable for numerical scales
-                max: undefined, // aaplicable for numerical scales
+                max: undefined, // applicable for numerical scales
                 orientation: "left", // top, bottom, left, right
                 padding: 0.15, // applicable for categorical scales
-                angle: 0
+                angle: 0,
+                display: true, // setting this to false will hide the title, ticks, tick labels, and title. leave as true to fine-tune axis display settings
+                hideAxis: false, // will hide the axis (ticks + tick labels)
+                hideTicks: false, // will hide the axis ticks
+                hideLabels: false, // will hide the axis tick labels
+                hideTitle: false // will hide the axis title
             },
             c: {
                 scaleType: undefined, // enum: ordinal, sequential. todo: add divergent
@@ -79,7 +87,7 @@ export class Plot {
             formatter:undefined // formatter - Function that takes a single argument (single datum for a particular plot) to generate HTML for tooltip
         };
         this.series = [];
-        this._changeSettings(userInput);     
+        this._changeSettings(userInput);
         
         // additional computed properties
         this.innerWidth = this.width - this.padding.left - this.padding.right;

--- a/src/views/Axis.js
+++ b/src/views/Axis.js
@@ -90,7 +90,7 @@ export default class Axis {
 
         let axis;
         const axisId = `${this.axisType}-axis`;
-        let axisFn = this._getAxisFn(this.orientation).scale(this._scale);
+        let axisFn = this._getAxisFn(this.orientation).scale(this._scale).tickSizeOuter(0);
 
         if (!plot.hasRendered) {
             axis = svg.append("g").attr("class", `ljs--${axisId}`);

--- a/src/views/Axis.js
+++ b/src/views/Axis.js
@@ -56,10 +56,10 @@ export default class Axis {
      * @param {d3 Selection} svg - plot d3 selection group
      * @param {Plot} plot
      */
-    _renderLabel(svg, plot) {
-        if (this.title === undefined) return;
+    _renderTitle(svg, plot) {
+        if (!this.display || this.title === undefined || this.hideTitle) return;
         const label = svg.append("text")
-            .attr("class", `ljs--${this.axisType}-axis-label`)
+            .attr("class", `ljs--${this.axisType}-axis-title`)
             .html(this.title);
 
         switch(this.orientation) {
@@ -92,7 +92,7 @@ export default class Axis {
 
         if (!plot.hasRendered) {
             axis = svg.append("g").attr("class", `ljs--${axisId}`);
-            this._renderLabel(svg, plot);
+            this._renderTitle(svg, plot);
             if (isNumericalScale(this.scaleType)) {
                 axisFn = axisFn.ticks(this.ticks);
             }
@@ -104,7 +104,7 @@ export default class Axis {
             } else if (this.orientation == axisOrientations.RIGHT) {
                 axis.attr("transform", `translate(${plot.innerWidth}, 0)`);
             }
-            axis.call(axisFn);
+            if (!this.hideAxis) axis.call(axisFn);
             
         } else {
             // TODO: need to test if text transformation remains in effect.

--- a/src/views/Axis.js
+++ b/src/views/Axis.js
@@ -57,7 +57,7 @@ export default class Axis {
      * @param {Plot} plot
      */
     _renderTitle(svg, plot) {
-        if (!this.display || this.title === undefined || this.hideTitle) return;
+        if (plot.hasRendered || this.display || this.title === undefined || this.hideTitle) return;
         const label = svg.append("text")
             .attr("class", `ljs--${this.axisType}-axis-title`)
             .html(this.title);
@@ -85,6 +85,8 @@ export default class Axis {
      */
     render(svg, plot) {
         if (!this.display) return;
+        this._renderTitle(svg, plot);
+        if (this.hideAxis) return;
 
         let axis;
         const axisId = `${this.axisType}-axis`;
@@ -92,11 +94,9 @@ export default class Axis {
 
         if (!plot.hasRendered) {
             axis = svg.append("g").attr("class", `ljs--${axisId}`);
-            this._renderTitle(svg, plot);
             if (isNumericalScale(this.scaleType)) {
                 axisFn = axisFn.ticks(this.ticks);
             }
-
             // translating axis to the appropriate location if necessary
             if (this.orientation == axisOrientations.BOTTOM) {
                 axis.attr("transform", `translate(0,${plot.innerHeight})`);
@@ -104,7 +104,7 @@ export default class Axis {
             } else if (this.orientation == axisOrientations.RIGHT) {
                 axis.attr("transform", `translate(${plot.innerWidth}, 0)`);
             }
-            if (!this.hideAxis) axis.call(axisFn);
+            axis.call(axisFn);
             
         } else {
             // TODO: need to test if text transformation remains in effect.
@@ -120,6 +120,12 @@ export default class Axis {
         if (this["text-anchor"]){
             axis.selectAll("text")
                 .style("text-anchor", this["text-anchor"]);
+        }
+        if (this.hideLabels) {
+            axis.selectAll(".tick > text").remove();
+        }
+        if (this.hideTicks) {
+            axis.selectAll(".tick > line").remove();
         }
     }
 

--- a/src/views/Axis.js
+++ b/src/views/Axis.js
@@ -9,7 +9,7 @@ import {isNumericalScale} from "../utils/plot-utils";
 export default class Axis {
     /**
      * Constructor for Axis object
-     * config properties include: scaleType, title, ticks, display, min, max, orientation, padding, angle, text-anchor
+     * config properties include: scaleType, title, ticks, display, min, max, orientation, padding, angle, textAnchor, hideAxis, hideTicks, hideLabels, hideTitle
     */
     constructor(axisType, config={}) {
         this.axisType = axisType;
@@ -117,9 +117,9 @@ export default class Axis {
                 .attr("dy", "-0.8em")
                 .attr("transform", `translate(0, 7) rotate(${this.angle})`); 
         }
-        if (this["text-anchor"]){
+        if (this.textAnchor){
             axis.selectAll("text")
-                .style("text-anchor", this["text-anchor"]);
+                .style("text-anchor", this.textAnchor);
         }
         if (this.hideLabels) {
             axis.selectAll(".tick > text").remove();


### PR DESCRIPTION
This PR provides additional customization options for the axis displays. There are 5 different options:

1. display -- toggles the display of all axis elements (the axis + title)
2. hideAxis -- toggles display of axis elements (everything minus the title)
3. hideTicks -- toggles the display of axis ticks
4. hideLabels -- toggles display of the axis tick labels
5. hideTitle -- toggles display of the axis title

Options 1 - 2 override all other options.
Outer ticks that square off the axis have also been removed, since that can be a little confusing in conjunction with the ability to specify number of ticks -- maybe worth more discussion, though?